### PR TITLE
Add zram swap service

### DIFF
--- a/packages/thorch-bsp/PKGBUILD
+++ b/packages/thorch-bsp/PKGBUILD
@@ -62,6 +62,7 @@ package() {
   chmod 755 "${pkgdir}/usr/bin/thorch-quicksetting-toggle"
   chmod 755 "${pkgdir}/usr/bin/thorch-usb-gadget"
   chmod 755 "${pkgdir}/usr/bin/thorch-usb-network"
+  chmod 755 "${pkgdir}/usr/bin/thorch-zram-swap"
   chmod 755 "${pkgdir}/usr/lib/thorch/plasma-mobile-action-drawer-mode"
   chmod 755 "${pkgdir}/usr/lib/initcpio/install/thorch-firmware"
   chmod 755 "${pkgdir}/usr/lib/initcpio/install/thorch-sd-prefer"

--- a/packages/thorch-bsp/payload/usr/bin/thorch-zram-swap
+++ b/packages/thorch-bsp/payload/usr/bin/thorch-zram-swap
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+device="${THORCH_ZRAM_DEVICE:-/dev/zram0}"
+size="${THORCH_ZRAM_SIZE:-12G}"
+algorithm="${THORCH_ZRAM_ALGORITHM:-lz4}"
+priority="${THORCH_ZRAM_PRIORITY:-100}"
+
+usage() {
+  cat <<'EOF'
+Usage: thorch-zram-swap start|stop|status
+
+Environment:
+  THORCH_ZRAM_DEVICE     zram block device to use (default: /dev/zram0)
+  THORCH_ZRAM_SIZE       uncompressed swap size (default: 12G)
+  THORCH_ZRAM_ALGORITHM  compression algorithm (default: lz4)
+  THORCH_ZRAM_PRIORITY   swap priority (default: 100)
+EOF
+}
+
+is_swapped() {
+  swapon --noheadings --show=NAME | grep -Fxq "${device}"
+}
+
+start_zram() {
+  if is_swapped; then
+    zramctl "${device}"
+    return 0
+  fi
+
+  modprobe zram num_devices=1
+  if [[ ! -b "${device}" ]]; then
+    device="$(zramctl --find)"
+  fi
+
+  if zramctl "${device}" >/dev/null 2>&1; then
+    zramctl --reset "${device}"
+  fi
+
+  device="$(zramctl --find --algorithm "${algorithm}" --size "${size}")"
+  mkswap -U clear "${device}" >/dev/null
+  swapon --priority "${priority}" "${device}"
+  zramctl "${device}"
+}
+
+stop_zram() {
+  if is_swapped; then
+    swapoff "${device}"
+  fi
+
+  if zramctl "${device}" >/dev/null 2>&1; then
+    zramctl --reset "${device}"
+  fi
+}
+
+case "${1:-}" in
+  start)
+    start_zram
+    ;;
+  stop)
+    stop_zram
+    ;;
+  status)
+    zramctl "${device}" || true
+    swapon --show
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/packages/thorch-bsp/payload/usr/lib/systemd/system/thorch-zram-swap.service
+++ b/packages/thorch-bsp/payload/usr/lib/systemd/system/thorch-zram-swap.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Thorch compressed RAM swap
+DefaultDependencies=no
+After=systemd-modules-load.service
+Before=swap.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/thorch-zram-swap start
+ExecStop=/usr/bin/thorch-zram-swap stop
+
+[Install]
+WantedBy=swap.target

--- a/packages/thorch-bsp/thorch-bsp.install
+++ b/packages/thorch-bsp/thorch-bsp.install
@@ -3,6 +3,7 @@ post_install() {
   if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
     systemctl disable --now thorch-hwcontrold.service thorch-powerkeyd.service >/dev/null 2>&1 || true
     systemctl enable --now thorch-inputd.service thorch-powerd.service >/dev/null 2>&1 || true
+    systemctl enable --now thorch-zram-swap.service >/dev/null 2>&1 || true
   fi
 }
 
@@ -11,5 +12,6 @@ post_upgrade() {
   if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
     systemctl disable --now thorch-hwcontrold.service thorch-powerkeyd.service >/dev/null 2>&1 || true
     systemctl enable --now thorch-inputd.service thorch-powerd.service >/dev/null 2>&1 || true
+    systemctl enable --now thorch-zram-swap.service >/dev/null 2>&1 || true
   fi
 }


### PR DESCRIPTION
## Summary
- Add a thorch-zram-swap helper for start, stop, and status operations.
- Add a systemd oneshot service that enables compressed RAM swap before swap.target.
- Enable the service on thorch-bsp install and upgrade.

## Why
Compressed RAM swap gives the handheld more breathing room under memory pressure without requiring disk-backed swap.

## Validation
- git diff --check HEAD^ HEAD
