### PR TITLE
Repair Steam ARM64 launch assets

### DIFF
--- a/packages/thorch-gaming-installers/PKGBUILD
+++ b/packages/thorch-gaming-installers/PKGBUILD
@@ -20,6 +20,7 @@ package() {
   chmod 755 "${pkgdir}/usr/bin/thorch-install-fex"
   chmod 755 "${pkgdir}/usr/bin/thorch-install-gaming-stack"
   chmod 755 "${pkgdir}/usr/bin/thorch-install-steam-arm64"
+  chmod 755 "${pkgdir}/usr/bin/thorch-repair-steam-arm64"
   chmod 755 "${pkgdir}/usr/bin/thorch-setup-steam-arm64"
   chmod 755 "${pkgdir}/usr/bin/thorch-start-steam-arm64"
   chmod 755 "${pkgdir}/usr/bin/thorch-steamos-mode"

--- a/packages/thorch-gaming-installers/payload/usr/bin/thorch-repair-steam-arm64
+++ b/packages/thorch-gaming-installers/payload/usr/bin/thorch-repair-steam-arm64
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+steam_root="${STEAM_STORAGE_ROOT:-${HOME}}/.local/share/Steam"
+steam_dotdir="${HOME}/.steam"
+
+link_first_existing() {
+  local link target
+
+  link="$1"
+  shift
+
+  for target in "$@"; do
+    if [[ -e "${target}" || -L "${target}" ]]; then
+      ln -sfnT "${target}" "${link}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+repair_launch_wrapper() {
+  local wrapper_dir wrapper_link
+
+  wrapper_dir="${steam_root}/steamrtarm64"
+  wrapper_link="${wrapper_dir}/steam-launch-wrapper"
+  [[ -d "${wrapper_dir}" ]] || return 0
+  [[ ! -e "${wrapper_link}" || -L "${wrapper_link}" ]] || return 0
+
+  if [[ -x "${steam_root}/linuxarm64/steam-launch-wrapper" ]]; then
+    ln -sfnT ../linuxarm64/steam-launch-wrapper "${wrapper_link}"
+  fi
+}
+
+repair_sdk_steamclient_links() {
+  mkdir -p "${steam_dotdir}/sdk64" "${steam_dotdir}/sdk32"
+
+  link_first_existing \
+    "${steam_dotdir}/sdk64/steamclient.so" \
+    "${steam_root}/linux64/steamclient.so" \
+    "${steam_root}/steamrt64/steamclient.so" || true
+
+  link_first_existing \
+    "${steam_dotdir}/sdk32/steamclient.so" \
+    "${steam_root}/linux32/steamclient.so" \
+    "${steam_root}/steamrt32/steamclient.so" \
+    "${steam_root}/ubuntu12_32/steamclient.so" || true
+}
+
+repair_launch_wrapper
+repair_sdk_steamclient_links

--- a/packages/thorch-gaming-installers/payload/usr/bin/thorch-setup-steam-arm64
+++ b/packages/thorch-gaming-installers/payload/usr/bin/thorch-setup-steam-arm64
@@ -450,6 +450,11 @@ mkdir -p "${steam_root}/steamrtarm64/bin"
 if [[ -x "${steam_root}/linuxarm64/steam-launch-wrapper" ]]; then
   ln -sfnT ../linuxarm64/steam-launch-wrapper "${steam_root}/steamrtarm64/steam-launch-wrapper"
 fi
+if [[ -x "${HOME}/.local/bin/thorch-repair-steam-arm64" ]]; then
+  "${HOME}/.local/bin/thorch-repair-steam-arm64" || true
+elif command -v thorch-repair-steam-arm64 >/dev/null 2>&1; then
+  thorch-repair-steam-arm64 || true
+fi
 ln -sfnT ../vgui2_s.so "${steam_root}/steamrtarm64/bin/vgui2_s.dll"
 ln -sfnT ../filesystem_stdio.so "${steam_root}/steamrtarm64/bin/FileSystem_Steam.dll"
 install_fex_steam_tool

--- a/packages/thorch-gaming-installers/payload/usr/bin/thorch-start-steam-arm64
+++ b/packages/thorch-gaming-installers/payload/usr/bin/thorch-start-steam-arm64
@@ -12,6 +12,9 @@ mangohud="${THORCH_STEAM_MANGOHUD:-auto}"
 mangohud_config="${THORCH_STEAM_MANGOHUD_CONFIG:-}"
 support_bin_dir="${steam_root}/thorch-steamos-bin"
 mangoapp_args=()
+steam_system_dir="${THORCH_STEAM_SYSTEM_DIR:-/usr/share/steam}"
+proton_arm_name="${THORCH_STEAM_PROTON_NAME:-Proton 11.0 (ARM64)}"
+preflight="${THORCH_STEAM_PREFLIGHT:-1}"
 
 runtime_lib_dir="$(find "${steam_root}/steam-runtime-steamrt-arm64" -path '*/files/lib/aarch64-linux-gnu' -type d -print -quit 2>/dev/null || true)"
 runtime_bin_dir="$(find "${steam_root}/steam-runtime-steamrt-arm64" -path '*/pressure-vessel/bin' -type d -print -quit 2>/dev/null || true)"
@@ -77,6 +80,17 @@ gamescope_supports_option() {
   gamescope --help 2>&1 | grep -q -- "${option}"
 }
 
+stage_proton_arm_manifest() {
+  local proton_dir source_manifest
+
+  source_manifest="${steam_system_dir}/toolmanifest.vdf"
+  [[ -f "${source_manifest}" ]] || return 0
+
+  proton_dir="${steam_root}/steamapps/common/${proton_arm_name}"
+  mkdir -p "${proton_dir}"
+  cp -f "${source_manifest}" "${proton_dir}/toolmanifest.vdf"
+}
+
 if [[ ! -x "${steam_root}/steamrtarm64/steam" ]]; then
   echo "Steam ARM64 is not installed. Run thorch-install-steam-arm64 first." >&2
   exit 1
@@ -87,6 +101,11 @@ if [[ -x "${HOME}/.local/bin/thorch-setup-steam-arm64" ]]; then
 elif command -v thorch-setup-steam-arm64 >/dev/null 2>&1; then
   thorch-setup-steam-arm64 --repair-proton-beta-runtime-links || true
 fi
+if [[ -x "${HOME}/.local/bin/thorch-repair-steam-arm64" ]]; then
+  "${HOME}/.local/bin/thorch-repair-steam-arm64" || true
+elif command -v thorch-repair-steam-arm64 >/dev/null 2>&1; then
+  thorch-repair-steam-arm64 || true
+fi
 
 configure_mangohud
 export LD_LIBRARY_PATH="${steam_root}/steamrtarm64:${steam_root}/steamrtarm64/video:${steam_root}/lib/aarch64-linux-gnu${runtime_lib_dir:+:${runtime_lib_dir}}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
@@ -96,15 +115,25 @@ export LANG="${LANG:-C.UTF-8}"
 export LC_ALL="${LC_ALL:-C.UTF-8}"
 cd "${steam_root}/steamrtarm64"
 
+stage_proton_arm_manifest
+case "${preflight,,}" in
+  1|true|yes|on|enabled)
+    ./steam -steamdeck -exitsteam || true
+    stage_proton_arm_manifest
+    ;;
+esac
+
+steam_bootstrap_args=(-noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles)
 steam_args=()
 case "${mode}" in
   desktop)
+    steam_args=("${steam_bootstrap_args[@]}")
     ;;
   deck|gamepadui)
-    steam_args=(-steamdeck -steamos3 -gamepadui)
+    steam_args=(-steamdeck -steamos3 -gamepadui "${steam_bootstrap_args[@]}")
     ;;
   bigpicture|*)
-    steam_args=(-bigpicture)
+    steam_args=(-bigpicture "${steam_bootstrap_args[@]}")
     ;;
 esac
 

--- a/tests/thorch-repair-steam-arm64.bash
+++ b/tests/thorch-repair-steam-arm64.bash
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="${root}/packages/thorch-gaming-installers/payload/usr/bin/thorch-repair-steam-arm64"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+steam_root="${tmp}/.local/share/Steam"
+mkdir -p \
+  "${steam_root}/linuxarm64" \
+  "${steam_root}/steamrtarm64" \
+  "${steam_root}/linux64" \
+  "${steam_root}/linux32"
+touch \
+  "${steam_root}/linuxarm64/steam-launch-wrapper" \
+  "${steam_root}/linux64/steamclient.so" \
+  "${steam_root}/linux32/steamclient.so"
+chmod 755 "${steam_root}/linuxarm64/steam-launch-wrapper"
+
+HOME="${tmp}" STEAM_STORAGE_ROOT="${tmp}" "${script}"
+
+wrapper="${steam_root}/steamrtarm64/steam-launch-wrapper"
+[[ -L "${wrapper}" ]] || fail "missing steamrtarm64 launch wrapper link"
+[[ "$(readlink "${wrapper}")" == "../linuxarm64/steam-launch-wrapper" ]] ||
+  fail "unexpected launch wrapper target: $(readlink "${wrapper}")"
+
+sdk64="${tmp}/.steam/sdk64/steamclient.so"
+sdk32="${tmp}/.steam/sdk32/steamclient.so"
+[[ -L "${sdk64}" ]] || fail "missing sdk64 steamclient link"
+[[ -L "${sdk32}" ]] || fail "missing sdk32 steamclient link"
+[[ "$(readlink "${sdk64}")" == "${steam_root}/linux64/steamclient.so" ]] ||
+  fail "unexpected sdk64 target: $(readlink "${sdk64}")"
+[[ "$(readlink "${sdk32}")" == "${steam_root}/linux32/steamclient.so" ]] ||
+  fail "unexpected sdk32 target: $(readlink "${sdk32}")"
+
+printf 'thorch Steam ARM64 repair tests passed\n'

--- a/tests/thorch-start-steam-arm64-launch-prep.bash
+++ b/tests/thorch-start-steam-arm64-launch-prep.bash
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="${root}/packages/thorch-gaming-installers/payload/usr/bin/thorch-start-steam-arm64"
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+steam_root="${tmp}/.local/share/Steam"
+system_steam="${tmp}/usr/share/steam"
+proton_dir="${steam_root}/steamapps/common/Proton 11.0 (ARM64)"
+log="${tmp}/steam-args.log"
+
+mkdir -p "${steam_root}/steamrtarm64" "${proton_dir}" "${system_steam}"
+cat > "${system_steam}/toolmanifest.vdf" <<'EOF'
+"manifest"
+{
+  "version" "2"
+  "commandline" "/proton %verb%"
+  "use_sessions" "1"
+  "compatmanager_layer_name" "proton"
+}
+EOF
+cat > "${proton_dir}/toolmanifest.vdf" <<'EOF'
+"manifest"
+{
+  "version" "2"
+  "commandline" "/proton %verb%"
+  "require_tool_appid" "4185400"
+}
+EOF
+cat > "${steam_root}/steamrtarm64/steam" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${THORCH_FAKE_STEAM_LOG:?}"
+exit 0
+EOF
+chmod 755 "${steam_root}/steamrtarm64/steam"
+
+HOME="${tmp}" \
+STEAM_STORAGE_ROOT="${tmp}" \
+THORCH_STEAM_SYSTEM_DIR="${system_steam}" \
+THORCH_STEAM_MODE=deck \
+THORCH_STEAM_USE_GAMESCOPE=0 \
+THORCH_FAKE_STEAM_LOG="${log}" \
+  "${script}"
+
+cmp -s "${system_steam}/toolmanifest.vdf" "${proton_dir}/toolmanifest.vdf" ||
+  fail "Proton ARM toolmanifest was not restored from system Steam assets"
+if grep -q 'require_tool_appid' "${proton_dir}/toolmanifest.vdf"; then
+  fail "Proton ARM manifest still requires Steam Linux Runtime 4.0 - Arm64"
+fi
+
+mapfile -t calls < "${log}"
+[[ "${#calls[@]}" -eq 2 ]] || fail "expected preflight and final Steam calls, got ${#calls[@]}"
+[[ "${calls[0]}" == "-steamdeck -exitsteam" ]] ||
+  fail "unexpected preflight args: ${calls[0]}"
+[[ "${calls[1]}" == *"-steamdeck -steamos3 -gamepadui"* ]] ||
+  fail "final launch is missing Steam Deck args: ${calls[1]}"
+for arg in -noverifyfiles -nobootstrapupdate -skipinitialbootstrap -norepairfiles; do
+  [[ "${calls[1]}" == *"${arg}"* ]] || fail "final launch is missing ${arg}: ${calls[1]}"
+done
+
+printf 'thorch Steam ARM64 launch prep tests passed\n'


### PR DESCRIPTION
## Summary
- Add a Steam ARM64 repair helper for launch wrapper and steamclient SDK symlinks.
- Run repair from setup and startup paths.
- Stage the Proton ARM toolmanifest from system Steam assets and add launch preflight/bootstrap arguments.
- Add focused tests for the repair helper and launch prep path.

## Why
Steam ARM64 startup can be brittle when wrapper, SDK, or Proton manifest assets drift. This repairs those assets before launching SteamOS mode.

## Validation
- tests/thorch-repair-steam-arm64.bash
- tests/thorch-start-steam-arm64-launch-prep.bash
- git diff --check HEAD^ HEAD
