### PR TITLE
Keep SteamOS mode windows visible to shell

### DIFF
--- a/packages/thorch-gaming-installers/payload/usr/bin/thorch-steamos-mode
+++ b/packages/thorch-gaming-installers/payload/usr/bin/thorch-steamos-mode
@@ -204,8 +204,8 @@ function applySteamMode(window) {
         console.info("thorch-steamos-mode: could not set fullscreen: " + e);
     }
     try {
-        window.skipTaskbar = true;
-        window.skipSwitcher = true;
+        window.skipTaskbar = false;
+        window.skipSwitcher = false;
     } catch (e) {
     }
 }
@@ -576,8 +576,8 @@ function moveWindow(window, output) {
         } catch (e) {
         }
         try {
-            window.skipTaskbar = true;
-            window.skipSwitcher = true;
+            window.skipTaskbar = false;
+            window.skipSwitcher = false;
         } catch (e) {
         }
     } else {


### PR DESCRIPTION
## Summary
- Stop marking SteamOS mode windows as skipped from taskbar and switcher.
- Apply the same visibility behavior to initially handled and moved windows.

## Why
SteamOS mode windows should remain visible to the shell so users can switch to and recover them normally.

## Validation
- git diff --check HEAD^ HEAD
