### PR TITLE
Remove forced SDL gamepad filtering

### DIFF
--- a/packages/thorch-rocknix-quirks/payload/etc/profile.d/thorch-rocknix-sm8550.sh
+++ b/packages/thorch-rocknix-quirks/payload/etc/profile.d/thorch-rocknix-sm8550.sh
@@ -64,11 +64,3 @@ if [ -z "${SDL_GAMEPADCONFIG_FILE:-}" ] &&
   [ -f /usr/share/thorch/SDL-GameControllerDB/gamecontrollerdb.txt ]; then
   export SDL_GAMEPADCONFIG_FILE="/usr/share/thorch/SDL-GameControllerDB/gamecontrollerdb.txt"
 fi
-
-if [ -z "${SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT:-}" ]; then
-  export SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT="${THORCH_SDL_GAMEPAD_IGNORE_EXCEPT:-0x045e/0x0b12}"
-fi
-
-if [ -z "${SDL_GAMEPAD_IGNORE_DEVICES_EXCEPT:-}" ]; then
-  export SDL_GAMEPAD_IGNORE_DEVICES_EXCEPT="${THORCH_SDL_GAMEPAD_IGNORE_EXCEPT:-0x045e/0x0b12}"
-fi


### PR DESCRIPTION
## Summary
- Remove forced SDL gamepad allow-list environment exports from the SM8550 ROCKNIX profile.

## Why
The global SDL filtering is too broad and can hide valid controllers/devices from applications that should handle them.

## Validation
- git diff --check HEAD^ HEAD
