### PR TITLE
linux-thorch: service UFS completions inline in hardirq during PM resume

### DIFF
--- a/packages/linux-thorch/dts-patches/0001-arm64-dts-qcom-qcs8550-ayn-thor-enable-built-in-mic.patch
+++ b/packages/linux-thorch/dts-patches/0001-arm64-dts-qcom-qcs8550-ayn-thor-enable-built-in-mic.patch
@@ -1,5 +1,5 @@
 From 7bf638771e7d26226eab92ab05f9d776ffdd8dde Mon Sep 17 00:00:00 2001
-From: Thorch Developers <thorch@local>
+From: jaewun <jaewun@users.noreply.github.com>
 Date: Sat, 9 May 2026 00:45:00 +1200
 Subject: [PATCH] arm64: dts: qcom: qcs8550-ayn-thor: enable built-in mic
 

--- a/packages/linux-thorch/dts-patches/0004-arm64-dts-qcom-qcs8550-ayn-thor-split-hall-lid-switch.patch
+++ b/packages/linux-thorch/dts-patches/0004-arm64-dts-qcom-qcs8550-ayn-thor-split-hall-lid-switch.patch
@@ -1,5 +1,5 @@
 From 3e2178c657ff2aebae061b38e064c63c5e2080bd Mon Sep 17 00:00:00 2001
-From: Thorch contributors <debug@thorch.local>
+From: jaewun <jaewun@users.noreply.github.com>
 Date: Sun, 17 May 2026 15:05:00 +1200
 Subject: [PATCH] arm64: dts: qcom: qcs8550-ayn-thor: split hall lid switch from
  gpio-keys

--- a/packages/linux-thorch/patches/0001-ASoC-wcd938x-add-DMIC-DAPM-inputs.patch
+++ b/packages/linux-thorch/patches/0001-ASoC-wcd938x-add-DMIC-DAPM-inputs.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Thorch Developers <thorch@local>
+From: jaewun <jaewun@users.noreply.github.com>
 Date: Fri, 8 May 2026 22:40:00 +1200
 Subject: [PATCH] ASoC: wcd938x: add DAPM input sources for DMIC widgets
 

--- a/packages/linux-thorch/patches/0003-thermal-qcom-tsens-skip-ayn-thor-uplow-wake-irq.patch
+++ b/packages/linux-thorch/patches/0003-thermal-qcom-tsens-skip-ayn-thor-uplow-wake-irq.patch
@@ -1,5 +1,5 @@
 From 2b4adfaf66434bddbde753c3ae7229d8c73a0ea5 Mon Sep 17 00:00:00 2001
-From: Thorch Debug <debug@thorch.local>
+From: jaewun <jaewun@users.noreply.github.com>
 Date: Mon, 11 May 2026 01:20:00 +1200
 Subject: [PATCH] thermal: qcom: tsens: skip AYN Thor uplow wake IRQs
 

--- a/packages/linux-thorch/patches/0005-scsi-ufs-service-completions-inline-in-hardirq-pm-resume.patch
+++ b/packages/linux-thorch/patches/0005-scsi-ufs-service-completions-inline-in-hardirq-pm-resume.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jaewun <jaewun@users.noreply.github.com>
+Date: Sat, 6 Jun 2026 20:40:00 +1200
+Subject: [PATCH] scsi: ufs: service completions inline in hardirq during PM
+ resume on non-MCQ controllers
+
+On a non-MCQ UFSHCI controller ufshcd_intr() defers all interrupt handling to
+the threaded handler, which is not scheduled during the device PM resume phase.
+After a deep system suspend the relink's completed UTP/UIC commands latch in
+REG_INTERRUPT_STATUS but are never serviced (the first device-management
+command waits forever), and a latched UIC_ERROR re-fires the level IRQ forever
+(interrupt storm).
+
+While pm_op_in_progress on a non-MCQ controller, service UTP/UIC/TMF completions
+inline in hardirq and W1C-ack + read-clear the UIC error-code registers so a
+transient resume-time error cannot storm, without invoking the PM-reentrant
+error handler.
+
+Signed-off-by: jaewun <jaewun@users.noreply.github.com>
+---
+ drivers/ufs/core/ufshcd.c | 39 ++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 38 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/ufs/core/ufshcd.c b/drivers/ufs/core/ufshcd.c
+--- a/drivers/ufs/core/ufshcd.c
++++ b/drivers/ufs/core/ufshcd.c
+@@ -7222,6 +7222,48 @@
+ 	struct ufs_hba *hba = __hba;
+ 	u32 intr_status, enabled_intr_status;
+ 
++	/*
++	 * On this non-MCQ controller interrupt handling is normally deferred to
++	 * the threaded handler, which is not scheduled during the deep-resume PM
++	 * phase. That leaves completed UTP/UIC commands latched in IS but never
++	 * serviced (the relink's first command waits forever), and a latched
++	 * UIC_ERROR re-fires the level IRQ forever (storm). While the controller
++	 * is resuming, service UTP/UIC/TMF completions inline in hardirq, and
++	 * W1C-ack + read-clear the UIC error-code registers so a transient
++	 * resume-time error cannot storm. Do not run ufshcd_check_errors() from
++	 * hardirq (it would schedule the error handler / link recovery, which is
++	 * reentrant during PM).
++	 */
++	if (!hba->mcq_enabled && hba->pm_op_in_progress) {
++		u32 status, compl_bits;
++
++		status = ufshcd_readl(hba, REG_INTERRUPT_STATUS) &
++			 ufshcd_readl(hba, REG_INTERRUPT_ENABLE);
++		if (!status)
++			return IRQ_HANDLED;
++
++		/* W1C exactly the snapshot we read. */
++		ufshcd_writel(hba, status, REG_INTERRUPT_STATUS);
++
++		if (status & UFSHCD_ERROR_MASK) {
++			/* read-to-clear all UIC error-code registers */
++			ufshcd_readl(hba, REG_UIC_ERROR_CODE_PHY_ADAPTER_LAYER);
++			ufshcd_readl(hba, REG_UIC_ERROR_CODE_DATA_LINK_LAYER);
++			ufshcd_readl(hba, REG_UIC_ERROR_CODE_NETWORK_LAYER);
++			ufshcd_readl(hba, REG_UIC_ERROR_CODE_TRANSPORT_LAYER);
++			ufshcd_readl(hba, REG_UIC_ERROR_CODE_DME);
++		}
++
++		compl_bits = status & (UTP_TRANSFER_REQ_COMPL | UFSHCD_UIC_MASK);
++		if (compl_bits & UFSHCD_UIC_MASK)
++			ufshcd_uic_cmd_compl(hba, compl_bits);
++		if (status & UTP_TASK_REQ_COMPL)
++			ufshcd_tmc_handler(hba);
++		if (compl_bits & UTP_TRANSFER_REQ_COMPL)
++			ufshcd_transfer_req_compl(hba);
++		return IRQ_HANDLED;
++	}
++
+ 	/* Move interrupt handling to thread when MCQ & ESI are not enabled */
+ 	if (!hba->mcq_enabled || !hba->mcq_esi_enabled)
+ 		return IRQ_WAKE_THREAD;

--- a/packages/thorch-bsp/payload/usr/lib/udev/rules.d/90-thorch-ufs-spm.rules
+++ b/packages/thorch-bsp/payload/usr/lib/udev/rules.d/90-thorch-ufs-spm.rules
@@ -1,7 +1,0 @@
-# Park the UFS controller at system-suspend power level 3 (device SLEEP, link
-# HIBERN8) instead of the SM8550 default level 5 (device POWERDOWN, link OFF).
-# no_phy_retention=true pins spm_lvl=5 in ufs-qcom, which forces a cold
-# POWERDOWN bring-up on every deep resume; that path intermittently storms
-# (-110 UIC timeouts) and hard-wedges. Suspending to SLEEP/HIBERN8 keeps enough
-# device state to re-init reliably. Validated 30/30 clean (0 storm, 0 wedge).
-ACTION=="add", SUBSYSTEM=="platform", KERNEL=="1d84000.ufshc", ATTR{spm_lvl}="3"


### PR DESCRIPTION
## Summary

Deep-suspend (S3) resume on the AYN Thor (SM8550, non-MCQ UFSHCI-4.0) could hang because `ufshcd_intr()` defers all interrupt handling to a threaded handler that is not scheduled during the PM resume phase. The completed UTP/UIC command from the resume relink latches in `REG_INTERRUPT_STATUS` and is never serviced, so the first command after the relink waits forever, and a latched `UIC_ERROR` re-fires the level IRQ. While the controller is resuming (`!mcq_enabled && pm_op_in_progress`), this patch services the UTP/UIC/TMF completions inline in hardirq and W1C-acks + read-clears the UIC error-code registers so a transient resume-time error cannot storm. It also drops the `90-thorch-ufs-spm.rules` override so UFS uses the upstream SM8550 `spm_lvl=5` default, and aligns patch authorship.

## Known limitation

A genuine cold link-startup error on resume — observed only after a long suspend dwell that follows a heavy GPU workload, on battery — is currently acknowledged in hardirq but not propagated to the synchronous resume path. As a result an error that could otherwise be recovered from (link-startup retry / reset-and-restore) is left unhandled. The common deep-resume hang is fixed; this rarer post-workload long-dwell case is still under investigation and may need the hardirq path to hand the failure back to the resume thread for recovery.