### PR TITLE
thorch-fex-bin: depend on qt6-declarative for FEXConfig GUI

### DIFF
--- a/packages/thorch-fex-bin/PKGBUILD
+++ b/packages/thorch-fex-bin/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=thorch-fex-bin
 pkgver=2605
-pkgrel=2
+pkgrel=3
 pkgdesc='ROCKNIX-imported FEX binary runtime for Thorch on AArch64'
 arch=(aarch64)
 url='https://github.com/FEX-Emu/FEX'
@@ -24,6 +24,7 @@ depends=(
   libxshmfence
   python
   qt6-base
+  qt6-declarative
   squashfs-tools
   squashfuse
   vulkan-icd-loader


### PR DESCRIPTION
## Summary
The `thorch-fex-bin` package ships the `FEXConfig` GUI and its launcher, but the GUI binary links `libQt6Quick.so.6` and `libQt6Qml.so.6`, which are provided by `qt6-declarative` — not `qt6-base` (the only Qt dependency listed before). Without `qt6-declarative` the FEXConfig launcher is effectively broken because its Qt Quick/Qml libraries are missing.

This adds `qt6-declarative` to `depends()` and bumps `pkgrel`.

## Test plan
- [ ] Confirm `qt6-declarative` is pulled in on a fresh install of `thorch-fex-bin`
- [ ] Launch FEXConfig from the Settings menu and verify the window opens