### PR TITLE
ci: run nightly on native arm64

### DIFF
--- a/.github/workflows/builder-image.yml
+++ b/.github/workflows/builder-image.yml
@@ -80,3 +80,63 @@ jobs:
           image="${IMAGE_REGISTRY}/${IMAGE_NAME}@${BUILDER_DIGEST}"
           printf 'Published immutable builder `%s`\n' "${image}" >> "${GITHUB_STEP_SUMMARY}"
           printf 'Use that digest in `.github/workflows/nightly.yml` only after its pull path has been verified.\n' >> "${GITHUB_STEP_SUMMARY}"
+
+  build-arm64:
+    name: Build Thorch Builder Image (arm64)
+    runs-on: ubuntu-24.04-arm
+    env:
+      IMAGE_NAME: thorch-build
+      IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      THORCH_DOCKER_BASE_IMAGE: menci/archlinuxarm:base-devel@sha256:7dfa70d355b9f4daf754a528b9f140c122952efbd9b52742d22379391835151b
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Prepare image metadata
+        id: metadata
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        with:
+          images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest-arm64,enable={{is_default_branch}}
+            type=sha,format=long,suffix=-arm64
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish builder image
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/arm64
+          build-args: THORCH_DOCKER_BASE_IMAGE=${{ env.THORCH_DOCKER_BASE_IMAGE }}
+          pull: true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          provenance: mode=max
+
+      - name: Record published builder digest
+        if: github.event_name != 'pull_request'
+        env:
+          BUILDER_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          [[ "${BUILDER_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "::error::ARM64 builder publication returned an invalid digest: ${BUILDER_DIGEST}"
+            exit 1
+          }
+          image="${IMAGE_REGISTRY}/${IMAGE_NAME}@${BUILDER_DIGEST}"
+          printf 'Published immutable ARM64 builder `%s`\n' "${image}" >> "${GITHUB_STEP_SUMMARY}"
+          printf 'Use that digest with `ubuntu-24.04-arm` only after its pull path has been verified.\n' >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,13 +42,13 @@ concurrency:
 jobs:
   build:
     name: Build Thorch Nightly
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 360
     env:
-      # Published by Builder Image run 29105361823. Update this digest only
+      # ARM64 image published by Builder Image run 29935184834. Update this digest only
       # after the replacement builder workflow reports and verifies its digest.
-      THORCH_BUILDER_DIGEST: sha256:47dafaf2248f956431fd8b6b1dd3318b2a1c90cd0db77c9e68cfc4d1f67dba63
-      THORCH_DOCKER_IMAGE: ghcr.io/${{ github.repository_owner }}/thorch-build@sha256:47dafaf2248f956431fd8b6b1dd3318b2a1c90cd0db77c9e68cfc4d1f67dba63
+      THORCH_BUILDER_DIGEST: sha256:8ef74e85679bbca19ed34ccd031ad11394d215cc38726e2bf0746e032fc9f541
+      THORCH_DOCKER_IMAGE: ghcr.io/${{ github.repository_owner }}/thorch-build@sha256:8ef74e85679bbca19ed34ccd031ad11394d215cc38726e2bf0746e032fc9f541
       THORCH_DOCKER_RUN_ARGS: --env THORCH_REQUIRE_MOUNT_INTEGRATION=1
       ROCKNIX_REF: ${{ inputs.rocknix_ref || 'next' }}
       ROCKNIX_KERNEL_SOURCE: nightly
@@ -74,11 +74,6 @@ jobs:
           sudo modprobe loop || true
           command -v docker
           command -v gh
-
-      - name: Register aarch64 emulation
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: arm64
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ THORCH_SUDO := sudo --preserve-env=$(THORCH_SUDO_ENV)
 
 comma := ,
 THORCH_DOCKER_IMAGE ?= ghcr.io/thorch-os/thorch-build:latest
-THORCH_DOCKER_BASE_IMAGE ?= $(shell if uname -m | grep -Eq '^(arm64|aarch64)$$'; then echo menci/archlinuxarm:base-devel; else sed -n 's/^ARG THORCH_DOCKER_BASE_IMAGE=//p' Dockerfile; fi)
+THORCH_DOCKER_ARM64_BASE_IMAGE ?= menci/archlinuxarm:base-devel@sha256:7dfa70d355b9f4daf754a528b9f140c122952efbd9b52742d22379391835151b
+THORCH_DOCKER_BASE_IMAGE ?= $(shell if uname -m | grep -Eq '^(arm64|aarch64)$$'; then echo '$(THORCH_DOCKER_ARM64_BASE_IMAGE)'; else sed -n 's/^ARG THORCH_DOCKER_BASE_IMAGE=//p' Dockerfile; fi)
 THORCH_DOCKER_CMD ?= $(shell if command -v docker >/dev/null 2>&1; then echo docker; elif command -v podman >/dev/null 2>&1; then echo podman; fi)
 THORCH_DOCKER_WORKDIR ?= /work
 THORCH_DOCKER_RUN_ARGS ?=

--- a/docs/build.md
+++ b/docs/build.md
@@ -134,11 +134,11 @@ The package repository and final image remain under `output/` in the checkout.
 Override `THORCH_DOCKER_BUILD_DIR` and `THORCH_DOCKER_BUILD_VOLUME` only when a
 different case-sensitive Docker storage location is required.
 
-On an `arm64` or `aarch64` host, `make docker-image-build` selects the native
-`menci/archlinuxarm:base-devel` base and builds kernels and Arch Linux ARM
-packages without CPU emulation. On x86_64 it uses the digest-pinned official
-`archlinux:base-devel` default declared by the Dockerfile and installs the
-aarch64 cross compiler and QEMU rootfs runner. Override
+On an `arm64` or `aarch64` host, `make docker-image-build` selects the native,
+digest-pinned `menci/archlinuxarm:base-devel` base and builds kernels and Arch
+Linux ARM packages without CPU emulation. On x86_64 it uses the digest-pinned
+official `archlinux:base-devel` default declared by the Dockerfile and installs
+the aarch64 cross compiler and QEMU rootfs runner. Override
 `THORCH_DOCKER_BASE_IMAGE` to use a different pinned or mirrored builder base.
 
 During userspace iteration, skip rebuilding/repackaging the kernel:

--- a/docs/nightly-actions.md
+++ b/docs/nightly-actions.md
@@ -6,21 +6,22 @@ It publishes the compressed image as a GitHub prerelease asset.
 No self-hosted Arch runner is required.
 
 The builder image is defined by `Dockerfile`. Default-branch runs of
-`.github/workflows/builder-image.yml` publish a convenience `latest` tag, a
-full commit-SHA tag, and report the resulting content digest. The nightly never
-uses the moving tags: it pulls the reviewed digest recorded in its workflow,
-for example:
+`.github/workflows/builder-image.yml` publish the existing AMD64 `latest` and
+full commit-SHA tags plus separate ARM64 `latest-arm64` and commit-SHA tags.
+Both jobs report their resulting content digest. The nightly never uses the
+moving tags: it pulls the reviewed, architecture-matched digest recorded in its
+workflow, for example:
 
 ```text
 ghcr.io/<owner>/thorch-build@sha256:<64-hex-digest>
 ```
 
-Pull requests build the image without pushing it, so Dockerfile changes are
-validated before merge. The Dockerfile also pins its Arch base image by digest.
-After a reviewed builder change lands, copy the new digest from the Builder
-Image job summary into `THORCH_BUILDER_DIGEST` and `THORCH_DOCKER_IMAGE` in the
-nightly workflow, then verify that exact digest can be pulled before relying on
-it for a release.
+Pull requests build both images without pushing them, so Dockerfile and
+architecture-specific base changes are validated before merge. The AMD64 and
+ARM64 base images are both pinned by digest. After a reviewed builder change
+lands, copy the matching digest from the Builder Image job summary into
+`THORCH_BUILDER_DIGEST` and `THORCH_DOCKER_IMAGE` in the nightly workflow, then
+verify that exact digest can be pulled before relying on it for a release.
 
 The nightly authenticates to GHCR, pulls only that digest, verifies the pulled
 repository digest, then runs `make docker-nightly`. It intentionally does not

--- a/docs/nightly-actions.md
+++ b/docs/nightly-actions.md
@@ -23,10 +23,10 @@ lands, copy the matching digest from the Builder Image job summary into
 `THORCH_BUILDER_DIGEST` and `THORCH_DOCKER_IMAGE` in the nightly workflow, then
 verify that exact digest can be pulled before relying on it for a release.
 
-The nightly authenticates to GHCR, pulls only that digest, verifies the pulled
-repository digest, then runs `make docker-nightly`. It intentionally does not
-fall back to a local build: such a fallback could publish with an unreviewed
-toolchain. Package and image rootfs commands use
+The nightly authenticates to GHCR, pulls only the ARM64 digest, verifies the
+pulled repository digest, then runs `make docker-nightly`. It intentionally
+does not fall back to a local build: such a fallback could publish with an
+unreviewed toolchain. Package and image rootfs commands use
 `THORCH_ROOTFS_RUNNER=chroot`, so the build does not need nested
 `systemd-nspawn`.
 
@@ -43,11 +43,13 @@ access in GitHub before changing the workflow.
 The job runs on:
 
 ```text
-ubuntu-latest
+ubuntu-24.04-arm
 ```
 
-The host step installs only release-side tooling (`zstd`) and uses Docker for
-the build environment. The Makefile wrapper runs the Thorch builder with
+This four-core ARM64 runner builds the aarch64 kernel, packages, and rootfs
+natively; it does not register QEMU binfmt handlers. The host step installs
+only release-side tooling (`zstd`) and uses Docker for the build environment.
+The Makefile wrapper runs the Thorch builder with
 `docker run --privileged`, matching the ROCKNIX-style "docker target wraps the
 normal make target" model. The privileged container is needed for loop devices,
 read-only ROCKNIX image imports, and kernel-mounted Btrfs population. The

--- a/packages/kwin/PKGBUILD
+++ b/packages/kwin/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=kwin
 pkgver=6.7.3
-pkgrel=6
+pkgrel=7
 pkgdesc='KWin with dual-screen placement and reliable forced input panels'
 arch=(aarch64)
 url='https://invent.kde.org/plasma/kwin'

--- a/packages/kwin/PKGBUILD
+++ b/packages/kwin/PKGBUILD
@@ -100,7 +100,7 @@ build() {
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_LIBEXECDIR=lib \
     -DBUILD_TESTING=OFF
-  cmake --build build --parallel 4
+  cmake --build build
 }
 
 check() {
@@ -110,7 +110,7 @@ check() {
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_LIBEXECDIR=lib \
     -DBUILD_TESTING=ON
-  cmake --build build --target testInputMethod --parallel 4
+  cmake --build build --target testInputMethod
 
   install -d -m 0700 "${runtime_dir}"
   dbus-run-session -- env \

--- a/packages/plasma-keyboard/PKGBUILD
+++ b/packages/plasma-keyboard/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=plasma-keyboard
 pkgver=6.7.3
-pkgrel=16
+pkgrel=17
 pkgdesc='Thorch-tuned Plasma on-screen keyboard'
 arch=(aarch64)
 url='https://invent.kde.org/plasma/plasma-keyboard'

--- a/packages/plasma-keyboard/PKGBUILD
+++ b/packages/plasma-keyboard/PKGBUILD
@@ -54,7 +54,7 @@ build() {
   cmake -B build -S "${pkgname}-${pkgver}" \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_TESTING=ON
-  cmake --build build --parallel 4
+  cmake --build build
 }
 
 check() {

--- a/tests/thorch-docker-build-path.bash
+++ b/tests/thorch-docker-build-path.bash
@@ -43,8 +43,8 @@ grep -q 'DisableSandbox' "${dockerfile}" ||
 grep -q 'THORCH_DOCKER_IMAGE ?= ghcr.io/thorch-os/thorch-build:latest' "${makefile}" ||
   fail "Makefile does not define the default Thorch builder image"
 
-grep -q 'menci/archlinuxarm:base-devel' "${makefile}" ||
-  fail "Makefile does not select an Arch Linux ARM builder on aarch64 hosts"
+grep -Eq 'THORCH_DOCKER_ARM64_BASE_IMAGE \?= menci/archlinuxarm:base-devel@sha256:[0-9a-f]{64}$' "${makefile}" ||
+  fail "Makefile does not pin its Arch Linux ARM builder base"
 
 grep -q '^docker-%:' "${makefile}" ||
   fail "Makefile does not provide ROCKNIX-style docker-* targets"
@@ -142,6 +142,21 @@ grep -q 'steps.build.outputs.digest' "${builder_workflow}" ||
 
 grep -q 'packages: write' "${builder_workflow}" ||
   fail "builder workflow cannot publish to GHCR"
+
+grep -q '^  build-arm64:' "${builder_workflow}" ||
+  fail "builder workflow does not publish a separate ARM64 builder"
+
+grep -A8 '^  build-arm64:' "${builder_workflow}" | grep -q 'runs-on: ubuntu-24.04-arm' ||
+  fail "ARM64 builder does not use GitHub's native ARM runner"
+
+grep -Eq 'THORCH_DOCKER_BASE_IMAGE: menci/archlinuxarm:base-devel@sha256:[0-9a-f]{64}$' "${builder_workflow}" ||
+  fail "ARM64 builder workflow does not pin its base image"
+
+grep -q 'platforms: linux/arm64' "${builder_workflow}" ||
+  fail "ARM64 builder workflow does not publish the ARM64 platform"
+
+grep -q 'type=sha,format=long,suffix=-arm64' "${builder_workflow}" ||
+  fail "ARM64 builder workflow does not publish an architecture-specific SHA tag"
 
 grep -q 'make docker-<target>' "${build_docs}" ||
   fail "build docs do not describe docker-* targets"

--- a/tests/thorch-nightly-workflow.bash
+++ b/tests/thorch-nightly-workflow.bash
@@ -25,14 +25,11 @@ grep -q 'contents: write' "${workflow}" ||
 grep -q 'packages: read' "${workflow}" ||
   fail "nightly workflow cannot authenticate to its GHCR builder"
 
-grep -q 'runs-on: ubuntu-latest' "${workflow}" ||
-  fail "nightly workflow is not using the GitHub-hosted Ubuntu runner"
+grep -q 'runs-on: ubuntu-24.04-arm' "${workflow}" ||
+  fail "nightly workflow is not using GitHub's native ARM64 runner"
 
-grep -Eq 'uses: docker/setup-qemu-action@[0-9a-f]{40}' "${workflow}" ||
-  fail "nightly workflow does not pin a QEMU registration action"
-
-grep -A3 'uses: docker/setup-qemu-action@' "${workflow}" | grep -q 'platforms: arm64' ||
-  fail "nightly workflow does not register aarch64 emulation"
+! grep -q 'docker/setup-qemu-action' "${workflow}" ||
+  fail "native ARM64 nightly still registers CPU emulation"
 
 grep -Eq 'THORCH_DOCKER_IMAGE: ghcr.io/[$][{][{] github[.]repository_owner [}][}]/thorch-build@sha256:[0-9a-f]{64}$' "${workflow}" ||
   fail "nightly workflow does not pin the published Thorch builder by digest"

--- a/tests/thorch-package-parallelism.bash
+++ b/tests/thorch-package-parallelism.bash
@@ -6,6 +6,8 @@ config="${root}/config/thorch.conf"
 builder="${root}/scripts/build-packages.sh"
 makefile="${root}/Makefile"
 build_docs="${root}/docs/build.md"
+kwin_pkgbuild="${root}/packages/kwin/PKGBUILD"
+keyboard_pkgbuild="${root}/packages/plasma-keyboard/PKGBUILD"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -22,6 +24,11 @@ grep -q 'THORCH_PACKAGE_JOBS' "${makefile}" ||
   fail "make does not preserve package build parallelism through sudo and Docker"
 grep -q '`THORCH_PACKAGE_JOBS`' "${build_docs}" ||
   fail "package build parallelism is not documented"
+
+for pkgbuild in "${kwin_pkgbuild}" "${keyboard_pkgbuild}"; do
+  ! grep -Eq -- '--parallel[[:space:]]+[0-9]+' "${pkgbuild}" ||
+    fail "${pkgbuild#"${root}/"} overrides THORCH_PACKAGE_JOBS with a fixed CMake job count"
+done
 
 failure="$(mktemp)"
 trap 'rm -f "${failure}"' EXIT


### PR DESCRIPTION
The x86 runner still reached only 63% of KWin after four hours, so the six-hour nightly remained at risk after fixing binfmt. Publish a digest-pinned native ARM64 builder alongside the existing AMD64 builder, run nightly on the GitHub ARM64 runner, and let the package-wide parallelism setting reach KWin and Plasma Keyboard.

Validated with the exact pinned ARM base locally (native aarch64), full docker-test and docker-audit, and successful builder publication run 29935184834. Exact native nightly run 29936317892 passed on head a00405a in 54m27s; all PR checks are green.